### PR TITLE
Updates to tripsService, entities

### DIFF
--- a/README.md
+++ b/README.md
@@ -209,7 +209,7 @@ Get all Trips:
 }
 ```
 
-Get a Trip, along with Route info, StopTimes with their associated stop and stop Point geometry, as well as the geometries for the shape associated with this trip (this is a `LineString` GeoJSON geometry, providin an array of coordinates to make up a path):
+Get a Trip, along with Route info, StopTimes with their associated stop and `Point` geometry:
 
 ```graphql
 {
@@ -221,20 +221,10 @@ Get a Trip, along with Route info, StopTimes with their associated stop and stop
       routeId
       routeDesc
     }
-    shape {
-      shapeGeom {
-        shapeId
-        geom {
-          type
-          coordinates
-        }
-      }
-    }
     stopTimes {
       stopId
       stopSequence
       stop {
-        stopId
         stopName
         stopDesc
         parentStation
@@ -242,6 +232,11 @@ Get a Trip, along with Route info, StopTimes with their associated stop and stop
           type
           coordinates
         }
+      }
+      departureTime {
+        hours
+        minutes
+        seconds
       }
     }
   }

--- a/src/entities/frequency.entity.ts
+++ b/src/entities/frequency.entity.ts
@@ -54,5 +54,5 @@ export class Frequency {
     { name: 'trip_id', referencedColumnName: 'tripId' },
   ])
   @Field(() => Trip)
-  trips: Trip;
+  trip: Trip;
 }

--- a/src/entities/stop-time.entity.ts
+++ b/src/entities/stop-time.entity.ts
@@ -7,7 +7,7 @@ import { PickupDropoffTypes } from 'entities/pickup-dropoff-types.entity';
 import { FeedInfo } from 'entities/feed-info.entity';
 import { Stop } from 'entities/stop.entity';
 import { Trip } from 'entities/trip.entity';
-import { Timepoints } from 'entities/timepoints.entity';
+import { Timepoint } from 'entities/timepoint.entity';
 import { Interval } from 'entities/interval.entity';
 
 @Index('arr_time_index', ['arrivalTimeSeconds'], {})
@@ -121,8 +121,8 @@ export class StopTime {
   @Field(() => PickupDropoffTypes)
   pickupType: PickupDropoffTypes;
 
-  @ManyToOne(() => Timepoints, (timepoints) => timepoints.stopTimes)
+  @ManyToOne(() => Timepoint, (timepoint) => timepoint.stopTimes)
   @JoinColumn([{ name: 'timepoint', referencedColumnName: 'timepoint' }])
-  @Field(() => Timepoints)
-  timepoint: Timepoints;
+  @Field(() => Timepoint)
+  timepoint: Timepoint;
 }

--- a/src/entities/stop-time.entity.ts
+++ b/src/entities/stop-time.entity.ts
@@ -1,4 +1,4 @@
-import { Field, Int, ObjectType } from '@nestjs/graphql';
+import { Field, Float, Int, ObjectType } from '@nestjs/graphql';
 import { Column, Entity, Index, JoinColumn, ManyToOne } from 'typeorm';
 import { IPostgresInterval } from 'postgres-interval';
 import { intervalTransformer } from 'transformers/';
@@ -57,8 +57,8 @@ export class StopTime {
     precision: 10,
     scale: 2,
   })
-  @Field({ nullable: true })
-  shapeDistTraveled: string | null;
+  @Field(() => Float, { nullable: true })
+  shapeDistTraveled: number | null;
 
   @Column('integer', { name: 'continuous_drop_off', nullable: true })
   @Field(() => Int, { nullable: true })

--- a/src/entities/timepoint.entity.ts
+++ b/src/entities/timepoint.entity.ts
@@ -5,7 +5,7 @@ import { StopTime } from 'entities/stop-time.entity';
 @Index('timepoints_pkey', ['timepoint'], { unique: true })
 @Entity('timepoints', { schema: 'gtfs' })
 @ObjectType()
-export class Timepoints {
+export class Timepoint {
   @Column('integer', { primary: true, name: 'timepoint' })
   @Field(() => Int)
   timepoint: number;

--- a/src/entities/trip.entity.ts
+++ b/src/entities/trip.entity.ts
@@ -77,7 +77,7 @@ export class Trip {
   @Field(() => Int, { nullable: true })
   bikesAllowed: number | null;
 
-  @OneToMany(() => Frequency, (frequency) => frequency.trips)
+  @OneToMany(() => Frequency, (frequency) => frequency.trip)
   @Field(() => [Frequency])
   frequencies: Frequency[];
 

--- a/src/schema.gql
+++ b/src/schema.gql
@@ -106,7 +106,7 @@ type Stop {
   transfers: [Transfer!]!
 }
 
-type Timepoints {
+type Timepoint {
   timepoint: Int!
   description: String
   stopTimes: [StopTime!]!
@@ -136,7 +136,7 @@ type StopTime {
   trip: Trip!
   dropOffType: PickupDropoffTypes!
   pickupType: PickupDropoffTypes!
-  timepoint: Timepoints!
+  timepoint: Timepoint!
 }
 
 type LineString {

--- a/src/schema.gql
+++ b/src/schema.gql
@@ -126,7 +126,7 @@ type StopTime {
   stopId: String
   stopSequence: Int
   stopHeadsign: String
-  shapeDistTraveled: String
+  shapeDistTraveled: Float
   continuousDropOff: Int
   arrivalTimeSeconds: Int
   departureTimeSeconds: Int

--- a/src/schema.gql
+++ b/src/schema.gql
@@ -37,7 +37,7 @@ type Frequency {
   startTimeSeconds: Int
   endTimeSeconds: Int
   feed: FeedInfo!
-  trips: Trip!
+  trip: Trip!
 }
 
 type ContinuousPickup {

--- a/src/trips/trips.module.ts
+++ b/src/trips/trips.module.ts
@@ -5,11 +5,12 @@ import * as redisStore from 'cache-manager-redis-store';
 import { TripsService } from 'trips/trips.service';
 import { TripsResolver } from 'trips/trips.resolver';
 import { Trip } from 'entities/trip.entity';
+import { Calendar } from 'entities/calendar.entity';
 import { CacheTtlSeconds } from 'constants/';
 
 @Module({
   imports: [
-    TypeOrmModule.forFeature([Trip]),
+    TypeOrmModule.forFeature([Trip, Calendar]),
     CacheModule.registerAsync({
       useFactory: (configService: ConfigService): CacheModuleOptions => ({
         store: redisStore,

--- a/src/trips/trips.module.ts
+++ b/src/trips/trips.module.ts
@@ -5,12 +5,13 @@ import * as redisStore from 'cache-manager-redis-store';
 import { TripsService } from 'trips/trips.service';
 import { TripsResolver } from 'trips/trips.resolver';
 import { Trip } from 'entities/trip.entity';
+import { StopTime } from 'entities/stop-time.entity';
 import { Calendar } from 'entities/calendar.entity';
 import { CacheTtlSeconds } from 'constants/';
 
 @Module({
   imports: [
-    TypeOrmModule.forFeature([Trip, Calendar]),
+    TypeOrmModule.forFeature([Trip, StopTime, Calendar]),
     CacheModule.registerAsync({
       useFactory: (configService: ConfigService): CacheModuleOptions => ({
         store: redisStore,

--- a/src/trips/trips.resolver.spec.ts
+++ b/src/trips/trips.resolver.spec.ts
@@ -2,14 +2,18 @@ import { CACHE_MANAGER } from '@nestjs/common';
 import { Test, TestingModule } from '@nestjs/testing';
 import { getRepositoryToken } from '@nestjs/typeorm';
 import { Trip } from 'entities/trip.entity';
+import { StopTime } from 'entities/stop-time.entity';
 import { TripsResolver } from 'trips/trips.resolver';
 import { TripsService } from 'trips/trips.service';
+import { Calendar } from 'entities/calendar.entity';
 
 describe('TripsResolver', () => {
   let resolver: TripsResolver;
 
   const mockCacheManager = {};
   const mockTripsRepository = {};
+  const mockStopTimeRepository = {};
+  const mockCalendarRepository = {};
 
   beforeEach(async () => {
     const module: TestingModule = await Test.createTestingModule({
@@ -23,6 +27,14 @@ describe('TripsResolver', () => {
         {
           provide: getRepositoryToken(Trip),
           useValue: mockTripsRepository,
+        },
+        {
+          provide: getRepositoryToken(StopTime),
+          useValue: mockStopTimeRepository,
+        },
+        {
+          provide: getRepositoryToken(Calendar),
+          useValue: mockCalendarRepository,
         },
       ],
     }).compile();

--- a/src/trips/trips.service.spec.ts
+++ b/src/trips/trips.service.spec.ts
@@ -3,6 +3,8 @@ import { getRepositoryToken } from '@nestjs/typeorm';
 import { CACHE_MANAGER } from '@nestjs/common';
 import { TripsService } from 'trips/trips.service';
 import { Trip } from 'entities/trip.entity';
+import { StopTime } from 'entities/stop-time.entity';
+import { Calendar } from 'entities/calendar.entity';
 
 describe('TripsService', () => {
   let service: TripsService;
@@ -10,12 +12,28 @@ describe('TripsService', () => {
   const mockTrip = {
     tripId: 'A',
   };
+
+  const mockStopTime = {};
+  const mockCalendar = {};
+
   const mockTripsRepository = {
     find: jest.fn().mockImplementation((): Promise<Trip[]> => {
       return Promise.resolve([mockTrip as Trip]);
     }),
     findOne: jest.fn().mockImplementation((): Promise<Trip> => {
       return Promise.resolve(mockTrip as Trip);
+    }),
+  };
+
+  const mockStopTimeRepository = {
+    findOne: jest.fn().mockImplementation((): Promise<StopTime> => {
+      return Promise.resolve(mockStopTime as StopTime);
+    }),
+  };
+
+  const mockCalendarRepository = {
+    getMany: jest.fn().mockImplementation((): Promise<Calendar[]> => {
+      return Promise.resolve([mockCalendar as Calendar]);
     }),
   };
 
@@ -35,6 +53,14 @@ describe('TripsService', () => {
         {
           provide: getRepositoryToken(Trip),
           useValue: mockTripsRepository,
+        },
+        {
+          provide: getRepositoryToken(StopTime),
+          useValue: mockStopTimeRepository,
+        },
+        {
+          provide: getRepositoryToken(Calendar),
+          useValue: mockCalendarRepository,
         },
         {
           provide: CACHE_MANAGER,

--- a/src/trips/trips.service.ts
+++ b/src/trips/trips.service.ts
@@ -11,6 +11,7 @@ import { Trip } from 'entities/trip.entity';
 import { GetTripArgs, GetTripsArgs } from 'trips/trips.args';
 import { CacheKeyPrefix } from 'constants/';
 import { formatCacheKey, getDayOfWeekForTimezone } from 'util/';
+import { StopTime } from 'entities/stop-time.entity';
 import { Calendar } from 'entities/calendar.entity';
 
 @Injectable()
@@ -18,6 +19,8 @@ export class TripsService {
   constructor(
     @Inject(CACHE_MANAGER)
     private readonly cacheManager: Cache,
+    @InjectRepository(StopTime)
+    private readonly stopTimeRepository: Repository<StopTime>,
     @InjectRepository(Trip)
     private readonly tripRepository: Repository<Trip>,
     @InjectRepository(Calendar)

--- a/src/trips/trips.service.ts
+++ b/src/trips/trips.service.ts
@@ -11,6 +11,7 @@ import { Trip } from 'entities/trip.entity';
 import { GetTripArgs, GetTripsArgs } from 'trips/trips.args';
 import { CacheKeyPrefix } from 'constants/';
 import { formatCacheKey, getDayOfWeekForTimezone } from 'util/';
+import { Calendar } from 'entities/calendar.entity';
 
 @Injectable()
 export class TripsService {
@@ -19,6 +20,8 @@ export class TripsService {
     private readonly cacheManager: Cache,
     @InjectRepository(Trip)
     private readonly tripRepository: Repository<Trip>,
+    @InjectRepository(Calendar)
+    private readonly calendarRepository: Repository<Calendar>,
   ) {}
 
   async getTrips(args: GetTripsArgs): Promise<Trip[]> {
@@ -34,23 +37,35 @@ export class TripsService {
       return tripsInCache;
     }
 
-    // TODO: Timezone should be dynamic, and match agencyTimezone:
-    const today = getDayOfWeekForTimezone('America/New_York');
-    const qb = this.tripRepository
+    const tripsQB = this.tripRepository
       .createQueryBuilder('t')
-      .innerJoinAndSelect('t.calendar', 'calendar')
-      .where('t.feedIndex=:feedIndex', { feedIndex })
-      .andWhere(`calendar.${today} = 1`);
+      .where('t.feedIndex=:feedIndex', { feedIndex });
 
     if (routeId) {
-      qb.andWhere('t.routeId = :routeId', { routeId });
+      tripsQB.andWhere('t.routeId = :routeId', { routeId });
     }
 
     if (serviceId) {
-      qb.andWhere('t.serviceId = :serviceId', { serviceId });
+      tripsQB.andWhere('t.serviceId = :serviceId', { serviceId });
+    } else {
+      // Collect serviceIds for current date in calendar
+      const today = getDayOfWeekForTimezone('America/New_York');
+      const calendarQB = this.calendarRepository
+        .createQueryBuilder('c')
+        .select(['c.serviceId'])
+        .where(`c.${today}=1`)
+        .andWhere('c.feedIndex=:feedIndex', { feedIndex });
+
+      const serviceIds: string[] = await (
+        await calendarQB.getMany()
+      ).map((calendar: Calendar) => calendar.serviceId);
+
+      if (serviceIds.length > 0) {
+        tripsQB.andWhere('t.serviceId IN (:...serviceIds)', { serviceIds });
+      }
     }
 
-    const trips: Trip[] = await qb.getMany();
+    const trips: Trip[] = await tripsQB.getMany();
     this.cacheManager.set(key, trips);
     return trips;
   }
@@ -70,8 +85,6 @@ export class TripsService {
         leftJoinAndSelect: {
           route: 'trip.route',
           stopTimes: 'trip.stopTimes',
-          shape: 'trip.shape',
-          shapegeom: 'shape.shapeGeom',
           stop: 'stopTimes.stop',
         },
       },

--- a/src/trips/trips.service.ts
+++ b/src/trips/trips.service.ts
@@ -86,6 +86,7 @@ export class TripsService {
           route: 'trip.route',
           stopTimes: 'trip.stopTimes',
           stop: 'stopTimes.stop',
+          locationType: 'stop.locationType',
         },
       },
     });

--- a/src/util/index.ts
+++ b/src/util/index.ts
@@ -29,13 +29,13 @@ export const formatCacheKey = (
 export const getDayOfWeekForTimezone = (zone: string): string => {
   const datetime = DateTime.fromObject(null, { zone });
   const daysOfWeek = [
-    'sunday',
     'monday',
     'tuesday',
     'wednesday',
     'thursday',
     'friday',
     'saturday',
+    'sunday',
   ];
   return daysOfWeek[datetime.weekday - 1];
 };


### PR DESCRIPTION
This PR mainly updates some fields in the entities/schema, as well as adds valid serviceId look ups for trips in `trips.service`. This also fixes a crash with certain datasets when joining Shape geometries to trips. In a future PR, I will look up a trip with `StopTime` departure in the immediate future, and join the geometries to that result to not only prevent this type of crash, but also to give us the correct Trip to return to the consumer. The main task here is to take the departure time from the `StopTime` at sequence `1`, and return the associated trip, along with the stop-times and shape. This shouldn't be difficult, it is just a matter of getting the current time and comparing it to the stop-time departure. As such, I've gone ahead and added the `StopTime` repository to the `tripsService` to implement next.