### PR TITLE
API updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -280,6 +280,8 @@ Get a Trip, along with Route info, StopTimes with their associated stop and `Poi
 
 [ [Table of Contents](#table-of-contents) ]
 
+### Querying Shapes
+
 Once we have trips, with their respective `shapeId`s, we can query for the actual shape geometry:
 
 Multiple shapes:
@@ -312,8 +314,6 @@ A single shape:
   }
 }
 ```
-
-### Querying Shapes
 
 [ [Table of Contents](#table-of-contents) ]
 

--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -1,12 +1,12 @@
 import { MiddlewareConsumer, Module } from '@nestjs/common';
 import { ConfigModule, ConfigService } from '@nestjs/config';
 import { TypeOrmModule, TypeOrmModuleAsyncOptions } from '@nestjs/typeorm';
+import { GraphQLModule } from '@nestjs/graphql';
 import { getConnectionOptions } from 'typeorm';
 import { join } from 'path';
 import authConfig from 'config/auth.config';
 import redisConfig from 'config/redis.config';
 import databaseConfig from 'config/database.config';
-import { GraphQLModule } from '@nestjs/graphql';
 import { AuthModule } from 'auth/auth.module';
 import { AuthMiddleware } from 'middleware/auth.middleware';
 import { FeedModule } from 'feeds/feed.module';

--- a/src/constants/index.ts
+++ b/src/constants/index.ts
@@ -13,5 +13,6 @@ export enum CacheKeyPrefix {
   FEEDS = 'feeds',
   ROUTES = 'routes',
   TRIPS = 'trips',
+  NEXT_TRIPS = 'next-trips',
   SHAPE = 'shape',
 }

--- a/src/entities/stop-time.entity.ts
+++ b/src/entities/stop-time.entity.ts
@@ -8,6 +8,7 @@ import { Stop } from 'entities/stop.entity';
 import { Trip } from 'entities/trip.entity';
 import { Timepoint } from 'entities/timepoint.entity';
 import { Interval } from 'entities/interval.entity';
+import { intervalToTime } from 'transformers';
 
 @Index('arr_time_index', ['arrivalTimeSeconds'], {})
 @Index('dep_time_index', ['departureTimeSeconds'], {})
@@ -30,9 +31,25 @@ export class StopTime {
   @Field(() => Interval, { nullable: true })
   arrivalTime: IPostgresInterval | null;
 
+  @Column('text', {
+    name: 'departure_time',
+    nullable: true,
+    transformer: intervalToTime,
+  })
+  @Field(() => String, { nullable: true })
+  arrival: string | null;
+
   @Column('interval', { name: 'departure_time', nullable: true })
   @Field(() => Interval, { nullable: true })
   departureTime: IPostgresInterval | null;
+
+  @Column('text', {
+    name: 'departure_time',
+    nullable: true,
+    transformer: intervalToTime,
+  })
+  @Field(() => String, { nullable: true })
+  departure: string | null;
 
   @Column('text', { name: 'stop_id', nullable: true })
   @Field({ nullable: true })

--- a/src/graphql/schema.gql
+++ b/src/graphql/schema.gql
@@ -308,9 +308,9 @@ type Query {
   feeds: [FeedInfo!]!
   routes(feedIndex: Int!): [Route!]!
   route(feedIndex: Int, routeId: String!): Route!
-  trips(feedIndex: Int!, routeId: String, serviceId: String): [Trip!]!
+  trips(feedIndex: Int!, routeId: String, tripIds: [String!]!): [Trip!]!
   trip(feedIndex: Int, tripId: String!): Trip!
-  nextTrip(feedIndex: Int, routeId: String!, directionId: Int = 0): Trip!
+  nextTrips(feedIndex: Int, routeId: String!): [Trip!]!
   stops(feedIndex: Int!, isParent: Boolean, isChild: Boolean, stopIds: [String!]): [Stop!]!
   stop(feedIndex: Int, stopId: String!): Stop!
   shapes(shapeIds: [String!]!): [ShapeGeom!]!

--- a/src/graphql/schema.gql
+++ b/src/graphql/schema.gql
@@ -122,7 +122,9 @@ type StopTime {
   feedIndex: Int!
   tripId: String
   arrivalTime: Interval
+  arrival: String
   departureTime: Interval
+  departure: String
   stopId: String
   stopSequence: Int
   stopHeadsign: String

--- a/src/transformers/index.ts
+++ b/src/transformers/index.ts
@@ -1,0 +1,19 @@
+import { IPostgresInterval } from 'postgres-interval';
+import { DateTime } from 'luxon';
+
+export const intervalToTime = {
+  to: (value: IPostgresInterval): IPostgresInterval => value,
+  from: (value: IPostgresInterval): string => {
+    const { hours: hour, minutes: minute, seconds: second } = value;
+
+    const time = DateTime.fromObject({
+      hour,
+      minute,
+      second,
+    })
+      .setZone('America/New_York')
+      .toLocaleString(DateTime.TIME_SIMPLE);
+
+    return time;
+  },
+};

--- a/src/trips/trips.args.ts
+++ b/src/trips/trips.args.ts
@@ -1,5 +1,5 @@
 import { ArgsType, Field, Int } from '@nestjs/graphql';
-import { IsNotEmpty, Max, Min } from 'class-validator';
+import { IsNotEmpty, Min } from 'class-validator';
 
 @ArgsType()
 export class GetTripsArgs {
@@ -8,10 +8,11 @@ export class GetTripsArgs {
   feedIndex: number;
 
   @Field({ nullable: true })
-  routeId: string;
+  routeId?: string;
 
-  @Field({ nullable: true })
-  serviceId: string;
+  @Field(() => [String])
+  @IsNotEmpty()
+  tripIds: string[];
 }
 
 @ArgsType()
@@ -26,7 +27,7 @@ export class GetTripArgs {
 }
 
 @ArgsType()
-export class GetNextTripArgs {
+export class GetNextTripsArgs {
   @Field(() => Int, { nullable: true })
   @Min(1)
   feedIndex: number;
@@ -34,8 +35,4 @@ export class GetNextTripArgs {
   @Field()
   @IsNotEmpty()
   routeId: string;
-
-  @Field(() => Int, { nullable: true, defaultValue: 0 })
-  @Max(1)
-  directionId: number;
 }

--- a/src/trips/trips.resolver.ts
+++ b/src/trips/trips.resolver.ts
@@ -1,6 +1,6 @@
 import { Args, Query, Resolver } from '@nestjs/graphql';
 import { Trip } from 'entities/trip.entity';
-import { GetNextTripArgs, GetTripArgs, GetTripsArgs } from './trips.args';
+import { GetNextTripsArgs, GetTripArgs, GetTripsArgs } from './trips.args';
 import { TripsService } from './trips.service';
 
 @Resolver()
@@ -17,8 +17,8 @@ export class TripsResolver {
     return this.tripsService.getTrip(getTripArgs);
   }
 
-  @Query(() => Trip, { name: 'nextTrip' })
-  getNextTrip(@Args() getNextTripsArgs: GetNextTripArgs): Promise<Trip> {
-    return this.tripsService.getNextTrip(getNextTripsArgs);
+  @Query(() => [Trip], { name: 'nextTrips' })
+  getNextTrips(@Args() getNextTripsArgs: GetNextTripsArgs): Promise<Trip[]> {
+    return this.tripsService.getNextTrips(getNextTripsArgs);
   }
 }

--- a/src/trips/trips.service.ts
+++ b/src/trips/trips.service.ts
@@ -46,7 +46,7 @@ export class TripsService {
       .createQueryBuilder('t')
       .innerJoinAndSelect('t.stopTimes', 'stopTimes')
       .innerJoinAndSelect('stopTimes.stop', 'stop')
-      .innerJoinAndSelect('stop.locationType', 'locationType')
+      .leftJoinAndSelect('stop.locationType', 'locationType')
       .where('t.feedIndex = :feedIndex', { feedIndex })
       .orderBy('stopTimes.stopSequence, stopTimes.departureTime', 'ASC');
 


### PR DESCRIPTION
This PR updates `nextTrip` functionality to return multiple upcoming trips. A transformer was created to convert Postgres Intervals to a simple time string, and added this to schema.