### PR TITLE
Add transfers to schema

### DIFF
--- a/README.md
+++ b/README.md
@@ -542,6 +542,61 @@ Which yields the following:
 
 [ [Table of Contents](#table-of-contents) ]
 
+#### Querying Transfers
+
+If you have a station ID (e.g., `127`, the `parentStation` of stop `127N` and `127S`), you can query for the stops associated with the `transfers` stations, for instance, if you are wanting to match a station with real-time `tripUpdate` and `vehicle` data, which is keyed by `stopId`:
+
+```graphql
+{
+  transfers(feedIndex: 1, parentStation: "127") {
+    stopId
+  }
+}
+```
+
+Which yields:
+
+```json
+{
+  "data": {
+    "transfers": [
+      {
+        "stopId": "127N"
+      },
+      {
+        "stopId": "127S"
+      },
+      {
+        "stopId": "725N"
+      },
+      {
+        "stopId": "725S"
+      },
+      {
+        "stopId": "902N"
+      },
+      {
+        "stopId": "902S"
+      },
+      {
+        "stopId": "A27N"
+      },
+      {
+        "stopId": "A27S"
+      },
+      {
+        "stopId": "R16N"
+      },
+      {
+        "stopId": "R16S"
+      }
+    ]
+  }
+}
+```
+
+From this, you can easily filter the results from the real-time feed to get updates relevant to that particular station. **NOTE** that this query returns full stop entities, so you can also query for name and geometry.
+
 ## Generated ERD
 
 The generated ERD of the PostgreSQL/PostGIS database:

--- a/src/graphql/schema.gql
+++ b/src/graphql/schema.gql
@@ -314,7 +314,8 @@ type Query {
   trip(feedIndex: Int, tripId: String!): Trip!
   nextTrips(feedIndex: Int, routeId: String!): [Trip!]!
   stops(feedIndex: Int!, isParent: Boolean, isChild: Boolean, stopIds: [String!]): [Stop!]!
-  stop(feedIndex: Int, stopId: String!): Stop!
+  stop(feedIndex: Int!, stopId: String!): Stop!
+  transfers(feedIndex: Int!, parentStation: String!): [Stop!]!
   shapes(shapeIds: [String!]!): [ShapeGeom!]!
   shape(shapeId: String!): ShapeGeom!
 }

--- a/src/stops/stops.args.ts
+++ b/src/stops/stops.args.ts
@@ -20,11 +20,21 @@ export class GetStopsArgs {
 
 @ArgsType()
 export class GetStopArgs {
-  @Field(() => Int, { nullable: true })
+  @Field(() => Int)
   @Min(1)
   feedIndex: number;
 
   @Field()
   @IsNotEmpty()
   stopId: string;
+}
+
+@ArgsType()
+export class GetTransfersArgs {
+  @Field(() => Int)
+  @Min(1)
+  feedIndex: number;
+
+  @Field(() => String)
+  parentStation: string;
 }

--- a/src/stops/stops.resolver.ts
+++ b/src/stops/stops.resolver.ts
@@ -1,7 +1,8 @@
 import { Args, Query, Resolver } from '@nestjs/graphql';
 import { Stop } from 'entities/stop.entity';
 import { StopsService } from 'stops/stops.service';
-import { GetStopArgs, GetStopsArgs } from 'stops/stops.args';
+import { GetStopArgs, GetStopsArgs, GetTransfersArgs } from 'stops/stops.args';
+
 @Resolver(() => Stop)
 export class StopsResolver {
   constructor(private readonly stopsService: StopsService) {}
@@ -14,5 +15,10 @@ export class StopsResolver {
   @Query(() => Stop, { name: 'stop' })
   getStop(@Args() getStopArgs: GetStopArgs): Promise<Stop> {
     return this.stopsService.getStop(getStopArgs);
+  }
+
+  @Query(() => [Stop], { name: 'transfers' })
+  getTransfers(@Args() getStopArgs: GetTransfersArgs): Promise<Stop[]> {
+    return this.stopsService.getTransfers(getStopArgs);
   }
 }

--- a/src/stops/stops.service.ts
+++ b/src/stops/stops.service.ts
@@ -120,6 +120,12 @@ export class StopsService {
       where: { feedIndex, stopId: parentStation },
     });
 
+    if (!station) {
+      throw new NotFoundException(
+        `Could not find station with feedIndex=${feedIndex} and stopId=${parentStation}!`,
+      );
+    }
+
     const { transfers } = station;
     const toStopIds = transfers.map((transfer: Transfer) => transfer.toStopId);
 


### PR DESCRIPTION
Add transfers query to schema. Provide  a station ID (`parentStation`) and a `feedIndex` to retrieve all of the stops that can be transferred to at this station. This is useful for knowing which `tripUpdate` and `vehicle` entities to retrieve from the real-time feed. If a station is provided and not found, this will throw a `NotFoundEsception`, as it means that either the data or the request parameters is invalid. 